### PR TITLE
Fix sync-induced spurious timestamps by tracking real editor changes only

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -225,10 +225,10 @@ export default class LogKeeperPlugin extends Plugin {
 		return `sig-${(hash >>> 0).toString(16)}`
 	}
 
-	/** 
+	/**
 	* Will attempt to update the 'last-modified' property of the frontmatter of the given file.
 	* @author James Sonneveld https://github.com/JimJamBimBam
-	* @param {TFile} file - The file that is having it's frontmatter updated.
+	* @param {TFile} file - The file that is having its frontmatter updated.
 	* @returns {Promise<void>} Nothing
 	*/
 	async updateFrontmatter(file: TFile): Promise<void> {
@@ -279,13 +279,13 @@ export default class LogKeeperPlugin extends Plugin {
 		})
 	}
 
-	/** 
+	/**
 	 * Compares the file parameter to the list of ignored folders, returning a boolean value.
 	 * @param {TFile} file File to compare with the ignored folders list.
 	 * @returns {boolean} Returns a boolean to say whether the file exists within the ignored folders.
 	 */
 	private fileWithinIgnoredFolders(file: TFile): boolean {
-		return this.settings.ignoredFolders.some((folder: string) => 
+		return this.settings.ignoredFolders.some((folder: string) =>
 			file.path.startsWith(folder + '/'))
 	}
 
@@ -293,7 +293,6 @@ export default class LogKeeperPlugin extends Plugin {
 	 * @param property the 'key' of the frontmatter.
 	 * @param fm the frontmatter object to get the property value from.
 	 * @returns Returns the YAML Property with the property name and value as one object.
-	 * Returns a YAML entry with both elements undefined if the array is undefined or empty.
 	 */
 	private getPropertyFromFrontMatter(property: string, fm: FrontMatterCache): YAMLProperty {
 		return {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { Plugin, TFile, moment, FrontMatterCache, MarkdownView } from 'obsidian'
+import { Plugin, TFile, moment, FrontMatterCache, MarkdownView, getFrontMatterInfo } from 'obsidian'
 import { LogKeeperTab, DEFAULT_SETTINGS, LogKeeperSettings } from './settings'
 import { Moment } from 'moment'
 
@@ -153,37 +153,26 @@ export default class LogKeeperPlugin extends Plugin {
 	}
 
 	private removeLastModifiedFromFrontmatter(content: string): string {
-		const lines = content.split(/\r?\n/)
-		if (lines.length === 0 || lines[0].trim() !== '---') {
+		const frontMatterInfo = getFrontMatterInfo(content)
+
+		if (!frontMatterInfo.exists) {
 			return content
 		}
 
-		let endFenceIndex = -1
-		for (let index = 1; index < lines.length; index++) {
-			if (lines[index].trim() === '---') {
-				endFenceIndex = index
-				break
-			}
-		}
-
-		if (endFenceIndex === -1) {
-			return content
-		}
-
-		const frontmatterLines = lines.slice(1, endFenceIndex)
-		const bodyLines = lines.slice(endFenceIndex + 1)
+		const frontmatterLines = frontMatterInfo.frontmatter.split(/\r?\n/)
+		const bodyContent = content.substring(frontMatterInfo.contentStart)
 		const filteredFrontmatter = this.removeTrackedPropertyFromFrontmatterLines(frontmatterLines)
 
 		if (filteredFrontmatter.length === 0) {
-			return bodyLines.join('\n')
+			return bodyContent
 		}
 
-		return `---\n${filteredFrontmatter.join('\n')}\n---\n${bodyLines.join('\n')}`
+		return `---\n${filteredFrontmatter.join('\n')}\n---\n${bodyContent}`
 	}
 
 	private removeTrackedPropertyFromFrontmatterLines(lines: string[]): string[] {
 		const filtered: string[] = []
-		const keyPattern = /^([ \t]*)(?:['"]?last-modified['"]?)\s*:(.*)$/
+		const keyPattern = /^(?:['"]?last-modified['"]?):.*$/
 
 		for (let index = 0; index < lines.length; index++) {
 			const line = lines[index]
@@ -193,23 +182,19 @@ export default class LogKeeperPlugin extends Plugin {
 				continue
 			}
 
-			const baseIndent = keyMatch[1].length
-			const valuePart = keyMatch[2].trim()
-
-			if (valuePart.length === 0 || valuePart === '|' || valuePart === '>') {
-				while (index + 1 < lines.length) {
-					const nextLine = lines[index + 1]
-					const nextIndent = nextLine.match(/^[ \t]*/)?.[0].length ?? 0
-					if (nextLine.trim().length === 0) {
-						index++
-						continue
-					}
-					if (nextIndent > baseIndent) {
-						index++
-						continue
-					}
-					break
+			// Skip continuation lines (list items in Obsidian format)
+			while (index + 1 < lines.length) {
+				const nextLine = lines[index + 1]
+				if (nextLine.trim().length === 0) {
+					index++
+					continue
 				}
+				const nextIndent = nextLine.match(/[\x20]{2}-[\x20]{1}.*/)?.[0].length ?? 0
+				if (nextIndent > 0) {
+					index++
+					continue
+				}
+				break
 			}
 		}
 
@@ -243,7 +228,7 @@ export default class LogKeeperPlugin extends Plugin {
 			const isOneModificationPerDay = this.settings.oneModificationPerDay
 			const updateInterval = this.settings.updateInterval
 
-			const existingEntries = this.getNormalizedTimestampEntries(yamlProperty.value, isOneModificationPerDay)
+			const existingEntries = this.getNormalizedTimestampEntries(yamlProperty.value)
 			const previousMoment = this.getLatestMomentFromEntries(existingEntries)
 			const currentMoment = moment()
 			const newEntry = currentMoment.format(TIMESTAMP_FORMAT)
@@ -274,7 +259,7 @@ export default class LogKeeperPlugin extends Plugin {
 			}
 
 			if (shouldWrite) {
-				frontmatter[LAST_MODIFIED_PROPERTY] = this.getNormalizedTimestampEntries(nextEntries, isOneModificationPerDay)
+				frontmatter[LAST_MODIFIED_PROPERTY] = this.getNormalizedTimestampEntries(nextEntries)
 			}
 		})
 	}
@@ -305,7 +290,7 @@ export default class LogKeeperPlugin extends Plugin {
 	 * Return a sorted and normalized array of timestamps from frontmatter.
 	 * Invalid entries are ignored.
 	 */
-	private getNormalizedTimestampEntries(value: unknown, oneModificationPerDay: boolean): string[] {
+	private getNormalizedTimestampEntries(value: unknown): string[] {
 		const parsedMoments: Moment[] = []
 		const values = Array.isArray(value) ? value : [value]
 
@@ -320,31 +305,9 @@ export default class LogKeeperPlugin extends Plugin {
 			}
 		}
 
-		parsedMoments.sort((left, right) => left.valueOf() - right.valueOf())
-
-		if (oneModificationPerDay) {
-			const latestByDay = new Map<string, Moment>()
-
-			for (const timestamp of parsedMoments) {
-				latestByDay.set(timestamp.format('YYYY-MM-DD'), timestamp)
-			}
-
-			return [...latestByDay.values()]
-				.sort((left, right) => left.valueOf() - right.valueOf())
-				.map((timestamp) => timestamp.format(TIMESTAMP_FORMAT))
-		}
-
-		const unique = new Set<string>()
-		const ordered: string[] = []
-		for (const timestamp of parsedMoments) {
-			const formatted = timestamp.format(TIMESTAMP_FORMAT)
-			if (!unique.has(formatted)) {
-				unique.add(formatted)
-				ordered.push(formatted)
-			}
-		}
-
-		return ordered
+		return parsedMoments
+			.sort((left, right) => left.valueOf() - right.valueOf())
+			.map((timestamp) => timestamp.format(TIMESTAMP_FORMAT))
 	}
 
 	/**

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,11 +1,15 @@
-import { Plugin, TFile, moment, FrontMatterCache } from 'obsidian'
+import { Plugin, TFile, moment, FrontMatterCache, MarkdownView } from 'obsidian'
 import { LogKeeperTab, DEFAULT_SETTINGS, LogKeeperSettings } from './settings'
 import { Moment } from 'moment'
 
 type YAMLProperty = {
 	property: string | undefined,
-	value: any | undefined
+	value: unknown
 }
+
+const LAST_MODIFIED_PROPERTY = 'last-modified'
+const TIMESTAMP_FORMAT = 'YYYY-MM-DDTHH:mm:ss'
+const DEBOUNCE_UPDATE_MS = 10_000
 
 /**
  * @author James Sonneveld
@@ -13,6 +17,9 @@ type YAMLProperty = {
  */
 export default class LogKeeperPlugin extends Plugin {
 	settings: LogKeeperSettings
+	private pendingUpdateTimers: Map<string, ReturnType<typeof setTimeout>> = new Map()
+	private pendingUpdateSignatures: Map<string, string> = new Map()
+	private lastMeaningfulSignatures: Map<string, string> = new Map()
 
 	async onload() {
 		await this.loadSettings()
@@ -20,19 +27,45 @@ export default class LogKeeperPlugin extends Plugin {
 		// This adds a settings tab so the user can configure various aspects of the plugin
 		this.addSettingTab(new LogKeeperTab(this.app, this))
 
-		// 'modify' event of  'this.app.vault' appears to be less buggy than
-		// 'editor-change' event in 'this.app.workspace'.
-		// If warning about 'file merging' happening too much,
-		// will need to consider another method of handling changes to files
-		this.registerEvent(this.app.vault.on('modify', (file) => {
-			if (file instanceof TFile) {
-				this.updateFrontmatter(file)
+		// editor-change can fire for programmatic changes as well as user edits.
+		// To avoid feedback loops, we only react when a normalized content signature
+		// (content excluding the tracked frontmatter property) has changed.
+		this.registerEvent(this.app.workspace.on('editor-change', (editor, info) => {
+			if (!(info instanceof MarkdownView) || !info.file) {
+				return
 			}
+
+			const file = info.file
+			if (this.fileWithinIgnoredFolders(file)) {
+				return
+			}
+
+			const currentSignature = this.getContentSignature(editor.getValue())
+			const previousSignature = this.lastMeaningfulSignatures.get(file.path)
+
+			// Prime baseline for this file in-memory. This avoids an unnecessary write
+			// on first editor-change after app/plugin restart.
+			if (previousSignature === undefined) {
+				this.lastMeaningfulSignatures.set(file.path, currentSignature)
+				return
+			}
+
+			if (previousSignature === currentSignature) {
+				return
+			}
+
+			this.lastMeaningfulSignatures.set(file.path, currentSignature)
+			this.scheduleFrontmatterUpdate(file, currentSignature)
 		}))
 	}
 
 	onunload() {
-
+		for (const timer of this.pendingUpdateTimers.values()) {
+			clearTimeout(timer)
+		}
+		this.pendingUpdateTimers.clear()
+		this.pendingUpdateSignatures.clear()
+		this.lastMeaningfulSignatures.clear()
 	}
 
 	async loadSettings() {
@@ -43,6 +76,155 @@ export default class LogKeeperPlugin extends Plugin {
 		await this.saveData(this.settings)
 	}
 
+	private scheduleFrontmatterUpdate(file: TFile, scheduledSignature: string): void {
+		const filePath = file.path
+		const existingTimer = this.pendingUpdateTimers.get(filePath)
+		if (existingTimer) {
+			clearTimeout(existingTimer)
+		}
+
+		this.pendingUpdateSignatures.set(filePath, scheduledSignature)
+
+		const timer = setTimeout(() => {
+			this.pendingUpdateTimers.delete(filePath)
+			void this.flushScheduledFrontmatterUpdate(file, scheduledSignature)
+		}, DEBOUNCE_UPDATE_MS)
+
+		this.pendingUpdateTimers.set(filePath, timer)
+	}
+
+	private async flushScheduledFrontmatterUpdate(file: TFile, scheduledSignature: string): Promise<void> {
+		const filePath = file.path
+
+		if (this.fileWithinIgnoredFolders(file)) {
+			this.pendingUpdateSignatures.delete(filePath)
+			return
+		}
+
+		const latestScheduledSignature = this.pendingUpdateSignatures.get(filePath)
+		if (latestScheduledSignature !== scheduledSignature) {
+			// Stale timer.
+			return
+		}
+
+		const latestMeaningfulSignature = this.lastMeaningfulSignatures.get(filePath)
+		if (latestMeaningfulSignature !== scheduledSignature) {
+			// Content changed again after this timer was scheduled.
+			return
+		}
+
+		const currentSignature = await this.getCurrentFileSignature(file)
+		if (currentSignature === null) {
+			return
+		}
+
+		if (currentSignature !== scheduledSignature) {
+			// The latest editor content changed since scheduling (e.g. more typing).
+			this.lastMeaningfulSignatures.set(filePath, currentSignature)
+			this.scheduleFrontmatterUpdate(file, currentSignature)
+			return
+		}
+
+		await this.updateFrontmatter(file)
+
+		// Keep the signature as-is. A plugin self-write only touches the tracked
+		// frontmatter property, so normalized content signature should not change.
+		this.pendingUpdateSignatures.delete(filePath)
+	}
+
+	private async getCurrentFileSignature(file: TFile): Promise<string | null> {
+		const activeView = this.app.workspace.getActiveViewOfType(MarkdownView)
+		if (activeView?.file?.path === file.path) {
+			return this.getContentSignature(activeView.editor.getValue())
+		}
+
+		try {
+			const content = await this.app.vault.cachedRead(file)
+			return this.getContentSignature(content)
+		}
+		catch {
+			return null
+		}
+	}
+
+	private getContentSignature(content: string): string {
+		const normalizedContent = this.removeLastModifiedFromFrontmatter(content)
+		return this.hashString(normalizedContent)
+	}
+
+	private removeLastModifiedFromFrontmatter(content: string): string {
+		const lines = content.split(/\r?\n/)
+		if (lines.length === 0 || lines[0].trim() !== '---') {
+			return content
+		}
+
+		let endFenceIndex = -1
+		for (let index = 1; index < lines.length; index++) {
+			if (lines[index].trim() === '---') {
+				endFenceIndex = index
+				break
+			}
+		}
+
+		if (endFenceIndex === -1) {
+			return content
+		}
+
+		const frontmatterLines = lines.slice(1, endFenceIndex)
+		const bodyLines = lines.slice(endFenceIndex + 1)
+		const filteredFrontmatter = this.removeTrackedPropertyFromFrontmatterLines(frontmatterLines)
+
+		if (filteredFrontmatter.length === 0) {
+			return bodyLines.join('\n')
+		}
+
+		return `---\n${filteredFrontmatter.join('\n')}\n---\n${bodyLines.join('\n')}`
+	}
+
+	private removeTrackedPropertyFromFrontmatterLines(lines: string[]): string[] {
+		const filtered: string[] = []
+		const keyPattern = /^([ \t]*)(?:['"]?last-modified['"]?)\s*:(.*)$/
+
+		for (let index = 0; index < lines.length; index++) {
+			const line = lines[index]
+			const keyMatch = line.match(keyPattern)
+			if (!keyMatch) {
+				filtered.push(line)
+				continue
+			}
+
+			const baseIndent = keyMatch[1].length
+			const valuePart = keyMatch[2].trim()
+
+			if (valuePart.length === 0 || valuePart === '|' || valuePart === '>') {
+				while (index + 1 < lines.length) {
+					const nextLine = lines[index + 1]
+					const nextIndent = nextLine.match(/^[ \t]*/)?.[0].length ?? 0
+					if (nextLine.trim().length === 0) {
+						index++
+						continue
+					}
+					if (nextIndent > baseIndent) {
+						index++
+						continue
+					}
+					break
+				}
+			}
+		}
+
+		return filtered
+	}
+
+	private hashString(input: string): string {
+		let hash = 5381
+		for (let index = 0; index < input.length; index++) {
+			hash = ((hash << 5) + hash) + input.charCodeAt(index)
+			hash |= 0
+		}
+		return `sig-${(hash >>> 0).toString(16)}`
+	}
+
 	/** 
 	* Will attempt to update the 'last-modified' property of the frontmatter of the given file.
 	* @author James Sonneveld https://github.com/JimJamBimBam
@@ -50,71 +232,53 @@ export default class LogKeeperPlugin extends Plugin {
 	* @returns {Promise<void>} Nothing
 	*/
 	async updateFrontmatter(file: TFile): Promise<void> {
-		await this.app.fileManager.processFrontMatter(file, (yamlData) => {
-			if (this.fileWithinIgnoredFolders(file)) {
-				// The folder the file is in is part of the exclusion list and should be ignored.
-				return
-			}
-			// Grab necessary settings as constants
-			const isOneModificationPerDay: boolean = this.settings.oneModificationPerDay
-			const updateInterval: number = this.settings.updateInterval
-			
-			// Makes the front matter type clearer by casting
-			const frontmatter = yamlData as FrontMatterCache
-			const yamlProperty: YAMLProperty = this.getPropertyFromFrontMatter('last-modified', frontmatter)
-			
-			const currentMoment: Moment = moment()
-			const previousMoment: Moment | null = this.getLatestMomentFromProperty(yamlProperty)
-			
-			// set to Infinity to start with. Will change if the current and previous moment can be found.
-			// at that point, a difference can be made and should be greater than 0 but less than Infinity.
-			let secondsSinceLastUpdate: number = Infinity
+		if (this.fileWithinIgnoredFolders(file)) {
+			return
+		}
 
-			// Setting one modification per day to true should always bypass the update interval that's set.
-			// This is achieved by keeping the seconds since last update set to Infinity,
-			// so that the comparison with the update interval always returns true.
-			if (!isOneModificationPerDay) {
+		await this.app.fileManager.processFrontMatter(file, (yamlData) => {
+			const frontmatter = yamlData as FrontMatterCache
+			const yamlProperty: YAMLProperty = this.getPropertyFromFrontMatter(LAST_MODIFIED_PROPERTY, frontmatter)
+
+			const isOneModificationPerDay = this.settings.oneModificationPerDay
+			const updateInterval = this.settings.updateInterval
+
+			const existingEntries = this.getNormalizedTimestampEntries(yamlProperty.value, isOneModificationPerDay)
+			const previousMoment = this.getLatestMomentFromEntries(existingEntries)
+			const currentMoment = moment()
+			const newEntry = currentMoment.format(TIMESTAMP_FORMAT)
+
+			let shouldWrite = false
+			const nextEntries = [...existingEntries]
+
+			if (isOneModificationPerDay) {
+				shouldWrite = true
+
+				if (previousMoment?.isValid() && currentMoment.isSame(previousMoment, 'day')) {
+					nextEntries[nextEntries.length - 1] = newEntry
+				}
+				else {
+					nextEntries.push(newEntry)
+				}
+			}
+			else {
+				let secondsSinceLastUpdate = Infinity
 				if (previousMoment?.isValid()) {
 					secondsSinceLastUpdate = currentMoment.diff(previousMoment, 'seconds')
 				}
+
+				if (secondsSinceLastUpdate > updateInterval) {
+					shouldWrite = true
+					nextEntries.push(newEntry)
+				}
 			}
-			
-			if (secondsSinceLastUpdate > updateInterval) {
-				const newEntry: string = currentMoment.format('YYYY-MM-DDTHH:mm:ss')
-				let newEntries: string[]
-				let finalIndex: number
 
-				if (Array.isArray(yamlProperty.value)) {
-					newEntries = yamlProperty.value
-					// Empty arrays could put index into negatives.
-					// Prevent by taking max.
-					finalIndex = Math.max((newEntries.length - 1), 0)
-				}
-				else {
-					newEntries = []
-					finalIndex = 0
-				}
-
-				// Must ignore one modification per day if there are no entries (previousMoment is null).
-				if (isOneModificationPerDay && previousMoment?.isValid()) {
-					if (currentMoment.isSame(previousMoment, 'day')) {
-						// Change the entry for the same day rather than pushing a new one
-						// to match the expected behaviour of 'one modification per day'.
-						newEntries[finalIndex] = newEntry
-					}
-					else {
-						newEntries.push(newEntry)
-					}
-				}
-				else {
-					newEntries.push(newEntry)
-				}
-			
-				frontmatter['last-modified'] = newEntries
+			if (shouldWrite) {
+				frontmatter[LAST_MODIFIED_PROPERTY] = this.getNormalizedTimestampEntries(nextEntries, isOneModificationPerDay)
 			}
 		})
 	}
-	
+
 	/** 
 	 * Compares the file parameter to the list of ignored folders, returning a boolean value.
 	 * @param {TFile} file File to compare with the ignored folders list.
@@ -139,24 +303,63 @@ export default class LogKeeperPlugin extends Plugin {
 	}
 
 	/**
-	 * Attempts to return the latest moment from the YAML property given whether that's single value or the last value in an array.
-	 * @param yamlProperty YAML property to pull the value from.
-	 * @returns Returns most recent moment from the yamlProperty or null if none is found.
+	 * Return a sorted and normalized array of timestamps from frontmatter.
+	 * Invalid entries are ignored.
 	 */
-	private getLatestMomentFromProperty(yamlProperty: YAMLProperty) {
-		const value: string | string[] | undefined = yamlProperty.value
-		let prevMoment: Moment | null = null
-		
-		// Check for the different types that 'value' could be.
-		if (Array.isArray(value)) {
-			const momentString: string = value[value.length - 1]
-			prevMoment = moment(momentString, 'YYYY-MM-DDTHH:mm:ss', true)
+	private getNormalizedTimestampEntries(value: unknown, oneModificationPerDay: boolean): string[] {
+		const parsedMoments: Moment[] = []
+		const values = Array.isArray(value) ? value : [value]
+
+		for (const entry of values) {
+			if (typeof entry !== 'string') {
+				continue
+			}
+
+			const parsed = moment(entry, TIMESTAMP_FORMAT, true)
+			if (parsed.isValid()) {
+				parsedMoments.push(parsed)
+			}
 		}
-		else if (String.isString(value)) {
-			prevMoment = moment(value, 'YYYY-MM-DDTHH:mm:ss', true)
+
+		parsedMoments.sort((left, right) => left.valueOf() - right.valueOf())
+
+		if (oneModificationPerDay) {
+			const latestByDay = new Map<string, Moment>()
+
+			for (const timestamp of parsedMoments) {
+				latestByDay.set(timestamp.format('YYYY-MM-DD'), timestamp)
+			}
+
+			return [...latestByDay.values()]
+				.sort((left, right) => left.valueOf() - right.valueOf())
+				.map((timestamp) => timestamp.format(TIMESTAMP_FORMAT))
 		}
-		
-		return prevMoment
+
+		const unique = new Set<string>()
+		const ordered: string[] = []
+		for (const timestamp of parsedMoments) {
+			const formatted = timestamp.format(TIMESTAMP_FORMAT)
+			if (!unique.has(formatted)) {
+				unique.add(formatted)
+				ordered.push(formatted)
+			}
+		}
+
+		return ordered
+	}
+
+	/**
+	 * Attempts to return the latest moment in an array of timestamps.
+	 * @param entries An ordered list of timestamp strings.
+	 * @returns Returns most recent moment from entries or null if none is found.
+	 */
+	private getLatestMomentFromEntries(entries: string[]): Moment | null {
+		if (entries.length === 0) {
+			return null
+		}
+
+		const latestEntry = entries[entries.length - 1]
+		const parsed = moment(latestEntry, TIMESTAMP_FORMAT, true)
+		return parsed.isValid() ? parsed : null
 	}
 }
-

--- a/src/main.ts
+++ b/src/main.ts
@@ -283,7 +283,7 @@ export default class LogKeeperPlugin extends Plugin {
 			const isOneModificationPerDay = this.settings.oneModificationPerDay
 			const updateInterval = this.settings.updateInterval
 
-			const existingEntries = this.getNormalizedTimestampEntries(yamlProperty.value, isOneModificationPerDay)
+			const existingEntries = this.getNormalizedTimestampEntries(yamlProperty.value)
 			const previousMoment = this.getLatestMomentFromEntries(existingEntries)
 			const currentMoment = moment()
 			const newEntry = currentMoment.format(TIMESTAMP_FORMAT)
@@ -314,7 +314,7 @@ export default class LogKeeperPlugin extends Plugin {
 			}
 
 			if (shouldWrite) {
-				frontmatter[LAST_MODIFIED_PROPERTY] = this.getNormalizedTimestampEntries(nextEntries, isOneModificationPerDay)
+				frontmatter[LAST_MODIFIED_PROPERTY] = this.getNormalizedTimestampEntries(nextEntries)
 			}
 		})
 	}
@@ -345,7 +345,7 @@ export default class LogKeeperPlugin extends Plugin {
 	 * Return a sorted and normalized array of timestamps from frontmatter.
 	 * Invalid entries are ignored.
 	 */
-	private getNormalizedTimestampEntries(value: unknown, oneModificationPerDay: boolean): string[] {
+	private getNormalizedTimestampEntries(value: unknown): string[] {
 		const parsedMoments: Moment[] = []
 		const values = Array.isArray(value) ? value : [value]
 
@@ -360,21 +360,8 @@ export default class LogKeeperPlugin extends Plugin {
 			}
 		}
 
-		parsedMoments.sort((left, right) => left.valueOf() - right.valueOf())
-
-		if (oneModificationPerDay) {
-			const latestByDay = new Map<string, Moment>()
-
-			for (const timestamp of parsedMoments) {
-				latestByDay.set(timestamp.format('YYYY-MM-DD'), timestamp)
-			}
-
-			return [...latestByDay.values()]
-				.sort((left, right) => left.valueOf() - right.valueOf())
-				.map((timestamp) => timestamp.format(TIMESTAMP_FORMAT))
-		}
-
 		return parsedMoments
+			.sort((left, right) => left.valueOf() - right.valueOf())
 			.map((timestamp) => timestamp.format(TIMESTAMP_FORMAT))
 	}
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,15 +1,21 @@
-import { Plugin, TFile, moment, FrontMatterCache, MarkdownView, getFrontMatterInfo } from 'obsidian'
+import { Plugin, TFile, Editor, moment, FrontMatterCache, MarkdownView, getFrontMatterInfo } from 'obsidian'
 import { LogKeeperTab, DEFAULT_SETTINGS, LogKeeperSettings } from './settings'
 import { Moment } from 'moment'
 
-type YAMLProperty = {
+interface YAMLProperty {
 	property: string | undefined,
 	value: unknown
 }
 
+interface FileState {
+	lastMeaningfulSignature?: string
+	pendingSignature?: string
+	timer?: ReturnType<typeof setTimeout>
+}
+
 const LAST_MODIFIED_PROPERTY = 'last-modified'
 const TIMESTAMP_FORMAT = 'YYYY-MM-DDTHH:mm:ss'
-const DEBOUNCE_UPDATE_MS = 10_000
+const DEBOUNCE_UPDATE_MS = 5_000
 
 /**
  * @author James Sonneveld
@@ -17,9 +23,7 @@ const DEBOUNCE_UPDATE_MS = 10_000
  */
 export default class LogKeeperPlugin extends Plugin {
 	settings: LogKeeperSettings
-	private pendingUpdateTimers: Map<string, ReturnType<typeof setTimeout>> = new Map()
-	private pendingUpdateSignatures: Map<string, string> = new Map()
-	private lastMeaningfulSignatures: Map<string, string> = new Map()
+	private fileStates: Map<string, FileState> = new Map()
 
 	async onload() {
 		await this.loadSettings()
@@ -34,38 +38,39 @@ export default class LogKeeperPlugin extends Plugin {
 			if (!(info instanceof MarkdownView) || !info.file) {
 				return
 			}
+			void this.handleEditorContentChange(info.file, editor)
+		}))
 
+		// editor-change does not reliably fire on paste. We listen to
+		// editor-paste separately to cover clipboard actions. The paste event
+		// fires *before* the pasted content is inserted into the editor, so we
+		// defer the signature check to the next tick via setTimeout.
+		this.registerEvent(this.app.workspace.on('editor-paste', (evt, editor, info) => {
+			if (evt.defaultPrevented) {
+				return
+			}
+			if (!(info instanceof MarkdownView) || !info.file) {
+				return
+			}
 			const file = info.file
-			if (this.fileWithinIgnoredFolders(file)) {
+			setTimeout(() => void this.handleEditorContentChange(file, editor), 0)
+		}))
+
+		this.registerEvent(this.app.workspace.on('file-open', (file) => {
+			if (!(file instanceof TFile) || file.extension !== 'md') {
 				return
 			}
-
-			const currentSignature = this.getContentSignature(editor.getValue())
-			const previousSignature = this.lastMeaningfulSignatures.get(file.path)
-
-			// Prime baseline for this file in-memory. This avoids an unnecessary write
-			// on first editor-change after app/plugin restart.
-			if (previousSignature === undefined) {
-				this.lastMeaningfulSignatures.set(file.path, currentSignature)
-				return
-			}
-
-			if (previousSignature === currentSignature) {
-				return
-			}
-
-			this.lastMeaningfulSignatures.set(file.path, currentSignature)
-			this.scheduleFrontmatterUpdate(file, currentSignature)
+			void this.ensurePersistedSignatureSeeded(file)
 		}))
 	}
 
 	onunload() {
-		for (const timer of this.pendingUpdateTimers.values()) {
-			clearTimeout(timer)
+		for (const state of this.fileStates.values()) {
+			if (state.timer) {
+				clearTimeout(state.timer)
+			}
 		}
-		this.pendingUpdateTimers.clear()
-		this.pendingUpdateSignatures.clear()
-		this.lastMeaningfulSignatures.clear()
+		this.fileStates.clear()
 	}
 
 	async loadSettings() {
@@ -76,51 +81,99 @@ export default class LogKeeperPlugin extends Plugin {
 		await this.saveData(this.settings)
 	}
 
-	private scheduleFrontmatterUpdate(file: TFile, scheduledSignature: string): void {
-		const filePath = file.path
-		const existingTimer = this.pendingUpdateTimers.get(filePath)
-		if (existingTimer) {
-			clearTimeout(existingTimer)
+	private getFileState(filePath: string): FileState {
+		let state = this.fileStates.get(filePath)
+		if (!state) {
+			state = {}
+			this.fileStates.set(filePath, state)
 		}
-
-		this.pendingUpdateSignatures.set(filePath, scheduledSignature)
-
-		const timer = setTimeout(() => {
-			this.pendingUpdateTimers.delete(filePath)
-			void this.flushScheduledFrontmatterUpdate(file, scheduledSignature)
-		}, DEBOUNCE_UPDATE_MS)
-
-		this.pendingUpdateTimers.set(filePath, timer)
+		return state
 	}
 
-	private async flushScheduledFrontmatterUpdate(file: TFile, scheduledSignature: string): Promise<void> {
-		const filePath = file.path
+	private async ensurePersistedSignatureSeeded(file: TFile): Promise<string | null> {
+		const state = this.getFileState(file.path)
+		if (state.lastMeaningfulSignature !== undefined) {
+			return state.lastMeaningfulSignature
+		}
 
+		try {
+			const signature = this.getContentSignature(await this.app.vault.cachedRead(file))
+			if (state.lastMeaningfulSignature === undefined) {
+				state.lastMeaningfulSignature = signature
+			}
+			return state.lastMeaningfulSignature ?? signature
+		}
+		catch {
+			return null
+		}
+	}
+
+	private async handleEditorContentChange(file: TFile, editor: Editor): Promise<void> {
 		if (this.fileWithinIgnoredFolders(file)) {
-			this.pendingUpdateSignatures.delete(filePath)
 			return
 		}
 
-		const latestScheduledSignature = this.pendingUpdateSignatures.get(filePath)
-		if (latestScheduledSignature !== scheduledSignature) {
+		const state = this.getFileState(file.path)
+		const currentSignature = this.getContentSignature(editor.getValue())
+		let previousSignature: string | null | undefined = state.lastMeaningfulSignature
+
+		if (previousSignature === undefined) {
+			previousSignature = await this.ensurePersistedSignatureSeeded(file)
+		}
+
+		if (previousSignature === currentSignature) {
+			state.lastMeaningfulSignature = currentSignature
+			return
+		}
+
+		state.lastMeaningfulSignature = currentSignature
+		this.scheduleFrontmatterUpdate(file, currentSignature)
+	}
+
+	private scheduleFrontmatterUpdate(file: TFile, scheduledSignature: string): void {
+		const state = this.getFileState(file.path)
+		if (state.timer) {
+			clearTimeout(state.timer)
+		}
+
+		state.pendingSignature = scheduledSignature
+
+		state.timer = setTimeout(() => {
+			state.timer = undefined
+			void this.flushScheduledFrontmatterUpdate(file, scheduledSignature)
+		}, DEBOUNCE_UPDATE_MS)
+	}
+
+	private async flushScheduledFrontmatterUpdate(file: TFile, scheduledSignature: string): Promise<void> {
+		const state = this.fileStates.get(file.path)
+		if (!state) {
+			return
+		}
+
+		if (this.fileWithinIgnoredFolders(file)) {
+			state.pendingSignature = undefined
+			return
+		}
+
+		if (state.pendingSignature !== scheduledSignature) {
 			// Stale timer.
 			return
 		}
 
-		const latestMeaningfulSignature = this.lastMeaningfulSignatures.get(filePath)
-		if (latestMeaningfulSignature !== scheduledSignature) {
+		if (state.lastMeaningfulSignature !== scheduledSignature) {
 			// Content changed again after this timer was scheduled.
 			return
 		}
 
 		const currentSignature = await this.getCurrentFileSignature(file)
 		if (currentSignature === null) {
+			state.pendingSignature = undefined
 			return
 		}
 
 		if (currentSignature !== scheduledSignature) {
 			// The latest editor content changed since scheduling (e.g. more typing).
-			this.lastMeaningfulSignatures.set(filePath, currentSignature)
+			state.lastMeaningfulSignature = currentSignature
 			this.scheduleFrontmatterUpdate(file, currentSignature)
 			return
 		}
@@ -129,13 +182,15 @@ export default class LogKeeperPlugin extends Plugin {
 
 		// Keep the signature as-is. A plugin self-write only touches the tracked
 		// frontmatter property, so normalized content signature should not change.
-		this.pendingUpdateSignatures.delete(filePath)
+		state.pendingSignature = undefined
 	}
 
 	private async getCurrentFileSignature(file: TFile): Promise<string | null> {
-		const activeView = this.app.workspace.getActiveViewOfType(MarkdownView)
-		if (activeView?.file?.path === file.path) {
-			return this.getContentSignature(activeView.editor.getValue())
+		for (const leaf of this.app.workspace.getLeavesOfType('markdown')) {
+			const view = leaf.view
+			if (view instanceof MarkdownView && view.file?.path === file.path) {
+				return this.getContentSignature(view.editor.getValue())
+			}
 		}
 
 		try {
@@ -228,7 +283,7 @@ export default class LogKeeperPlugin extends Plugin {
 			const isOneModificationPerDay = this.settings.oneModificationPerDay
 			const updateInterval = this.settings.updateInterval
 
-			const existingEntries = this.getNormalizedTimestampEntries(yamlProperty.value)
+			const existingEntries = this.getNormalizedTimestampEntries(yamlProperty.value, isOneModificationPerDay)
 			const previousMoment = this.getLatestMomentFromEntries(existingEntries)
 			const currentMoment = moment()
 			const newEntry = currentMoment.format(TIMESTAMP_FORMAT)
@@ -259,7 +314,7 @@ export default class LogKeeperPlugin extends Plugin {
 			}
 
 			if (shouldWrite) {
-				frontmatter[LAST_MODIFIED_PROPERTY] = this.getNormalizedTimestampEntries(nextEntries)
+				frontmatter[LAST_MODIFIED_PROPERTY] = this.getNormalizedTimestampEntries(nextEntries, isOneModificationPerDay)
 			}
 		})
 	}
@@ -290,7 +345,7 @@ export default class LogKeeperPlugin extends Plugin {
 	 * Return a sorted and normalized array of timestamps from frontmatter.
 	 * Invalid entries are ignored.
 	 */
-	private getNormalizedTimestampEntries(value: unknown): string[] {
+	private getNormalizedTimestampEntries(value: unknown, oneModificationPerDay: boolean): string[] {
 		const parsedMoments: Moment[] = []
 		const values = Array.isArray(value) ? value : [value]
 
@@ -305,8 +360,21 @@ export default class LogKeeperPlugin extends Plugin {
 			}
 		}
 
+		parsedMoments.sort((left, right) => left.valueOf() - right.valueOf())
+
+		if (oneModificationPerDay) {
+			const latestByDay = new Map<string, Moment>()
+
+			for (const timestamp of parsedMoments) {
+				latestByDay.set(timestamp.format('YYYY-MM-DD'), timestamp)
+			}
+
+			return [...latestByDay.values()]
+				.sort((left, right) => left.valueOf() - right.valueOf())
+				.map((timestamp) => timestamp.format(TIMESTAMP_FORMAT))
+		}
+
 		return parsedMoments
-			.sort((left, right) => left.valueOf() - right.valueOf())
 			.map((timestamp) => timestamp.format(TIMESTAMP_FORMAT))
 	}
 


### PR DESCRIPTION
This PR addresses the behavior described in #23: notes can get `last-modified` updates on a device even when the user did not edit there (e.g. after Obsidian Sync writes files), which can also contribute to cross-device timestamp churn.

The core goal is to only timestamp **actual editing activity**, while avoiding self-triggered update loops.

## Motivation (from #23)
Using `vault.on("modify")` (or equivalent file-write-triggered paths) can treat non-user file writes as edits. With Obsidian Sync, this means synced notes may receive new timestamps that reflect sync time rather than authoring time. In multi-device setups, this can create repeated timestamp propagation.

As proposed in #23, this PR is aligned with a **user-edit-centric** model.

## What this PR changes
- Uses `workspace.on("editor-change")` as the edit signal (user/editor transaction context).
- Adds a **10s debounce** so frontmatter isn’t rewritten on every keystroke.
- Ensures **last scheduled update wins** (stale queued updates are discarded).
- Adds **content-signature gating**:
  - signature is computed from note content with `last-modified` removed,
  - plugin only schedules updates when that normalized content actually changes,
  - prevents plugin self-writes from re-triggering infinite update loops.
- Primes baseline signature after restart so opening/initial editor activity does not cause an unnecessary write.
- Preserves and tightens timestamp list hygiene:
  - sorted timestamps,
  - invalid entries ignored,
  - duplicates removed,
  - one-per-day mode enforces a single (latest) entry per day.

## Behavioral result
- Sync/file-system writes without meaningful editor content changes no longer cause repeated timestamp churn.
- Timestamp updates occur after editing settles, not continuously while typing.
- Self-induced loops are prevented without relying on brittle event ordering assumptions.

## Tradeoff
As in #23’s discussion, `editor-change` is scoped to editor-driven changes. This is intentional: only notes being actively edited should be timestamped.

## Testing
- Built successfully with `npm run build`
- Manual validation in local vault:
  - no immediate write while typing,
  - write after debounce idle,
  - stale updates canceled during continued typing,
  - no repeating self-trigger loop,
  - one-per-day semantics retained.
